### PR TITLE
build-winemono.sh: give a more descriptive message when --recursive wasn't used when cloning

### DIFF
--- a/build-winemono.sh
+++ b/build-winemono.sh
@@ -494,7 +494,12 @@ cd "$SRCDIR"/mono
 
 if test 1 != $REBUILD || test ! -e configure; then
     # create configure script and such
-    NOCONFIGURE=yes ./autogen.sh || exit 1
+    if test ! -f ./autogen.sh; then
+        echo "./autogen.sh was not found! Did you forget to use --recursive when cloning?"
+        exit 1
+    else
+        NOCONFIGURE=yes ./autogen.sh || exit 1
+    fi
 
     BUILD="`./config.guess`"
 


### PR DESCRIPTION
Otherwise you only get:
```
$ ./build-winemono.sh 
./build-winemono.sh: 497: ./build-winemono.sh: ./autogen.sh: not found
```