### PR TITLE
Add csc.exe in C:\windows\Microsoft.NET\Framework version folders

### DIFF
--- a/build-winemono.sh
+++ b/build-winemono.sh
@@ -190,6 +190,9 @@ build_cli ()
     cp "$BUILDDIR/build-cross-cli-install/lib/mono/2.0-api/mscorlib.dll" "$BUILDDIR/image/2.0-mscorlib.dll"
     cp "$BUILDDIR/build-cross-cli-install/lib/mono/4.0/mscorlib.dll" "$BUILDDIR/image/4.0-mscorlib.dll"
 
+	mcs "$SRCDIR/csc-wrapper.cs" /d:VERSION40 -out:"$BUILDDIR"/image/4.0-csc.exe -r:Mono.Posix || exit 1
+	mcs "$SRCDIR/csc-wrapper.cs" /d:VERSION20 -out:"$BUILDDIR"/image/2.0-csc.exe -r:Mono.Posix || exit 1
+
     # remove debug files
 	cd "$BUILDDIR"
     for f in `find image|grep -E '\.(mdb|pdb)$'`; do
@@ -388,6 +391,14 @@ build_filetable ()
         4.0-mscorlib.dll)
             COMPONENT=framework40-folder
             BASENAME=mscorlib.dll
+        ;;
+		2.0-csc.exe)
+            COMPONENT=framework20-folder
+            BASENAME=csc.exe
+        ;;
+		4.0-csc.exe)
+            COMPONENT=framework40-folder
+            BASENAME=csc.exe
         ;;
         *)
             COMPONENT=`dirname "$f"|sed -e 's/\//|/g'`

--- a/csc-wrapper.cs
+++ b/csc-wrapper.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Diagnostics;
+
+class CscWrapper
+{
+
+#if VERSION20
+    const string VERSION_STRING = "2.0-api";
+#elif VERSION40
+    const string VERSION_STRING = "4.0-api";
+#endif
+
+    static void Main(string[] arguments)
+    {
+        var addStdlib = true;
+
+        for (int i = 0; i< arguments.Length; i++)
+        {
+            if (arguments[i] == "/nostdlib" || arguments[i] == "-nostdlib")
+               addStdlib = false;
+            arguments[i] = '"' + arguments[i] + '"';
+        }
+
+        var versionArguments = "";
+        if (addStdlib)
+            versionArguments = String.Format(@"/nostdlib /r:c:\windows\mono\mono-2.0\lib\mono\{0}\mscorlib.dll /lib:c:\windows\mono\mono-2.0\lib\mono\{0} ", VERSION_STRING);
+
+        var process = new Process();
+        process.StartInfo.FileName = @"c:\windows\mono\mono-2.0\lib\mono\4.5\mcs.exe";
+        process.StartInfo.Arguments = versionArguments + String.Join(" ", arguments);
+        process.StartInfo.CreateNoWindow = true;
+        process.StartInfo.UseShellExecute = false;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.OutputDataReceived += (sender, args) => Console.WriteLine(args.Data);
+        process.Start();
+        process.BeginOutputReadLine();
+        process.WaitForExit();
+    }
+}
+


### PR DESCRIPTION
This adds the compiler csc.exe for .NET 2.0 and 4.0.
Since .NET has multiple csc (one for every .NET version), we also need multiple. This is the simplest approach I found, a simple wrapper that calls the mono compiler and specifies the requested API.