### PR TITLE
Makefile: Expicitly disable vsscanf when compiling libSDL2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,9 +154,10 @@ tests: tests-runtime-$(1)
 
 # FNA native deps
 # SDL2
+# note: we explicitly disable vsscanf as msvcrt doesn't support it and mingw-w64's wrapper is buggy
 $$(BUILDDIR)/SDL2-$(1)/Makefile: $$(SRCDIR)/SDL2/configure $$(SRCDIR)/mono/configure
 	mkdir -p $$(@D)
-	cd $$(BUILDDIR)/SDL2-$(1); CC="$$(MINGW_$(1))-gcc -static-libgcc" CXX="$$(MINGW_$(1))-g++ -static-libgcc -static-libstdc++" $$(SRCDIR_ABS)/SDL2/configure --build=$$(shell $$(SRCDIR)/mono/config.guess) --target=$$(MINGW_$(1)) --host=$$(MINGW_$(1)) PKG_CONFIG=false
+	cd $$(BUILDDIR)/SDL2-$(1); CC="$$(MINGW_$(1))-gcc -static-libgcc" CXX="$$(MINGW_$(1))-g++ -static-libgcc -static-libstdc++" $$(SRCDIR_ABS)/SDL2/configure --build=$$(shell $$(SRCDIR)/mono/config.guess) --target=$$(MINGW_$(1)) --host=$$(MINGW_$(1)) PKG_CONFIG=false ac_cv_func_vsscanf=no
 
 $$(BUILDDIR)/SDL2-$(1)/.built: $$(BUILDDIR)/SDL2-$(1)/Makefile $$(SDL2_SRCS)
 	+WINEPREFIX=/dev/null $$(MAKE) -C $$(BUILDDIR)/SDL2-$(1) TARGET=libSDL2-$(1).la


### PR DESCRIPTION
msvcrt.dll doesn't support vsscanf. mingw-w64 uses a wrapper to convert it to
sscanf, but this wrapper is imperfect; it currently suffers from a bug
causing register corruption, and even with that fixed it copies a fixed
number of arguments to the stack, which will obviously fail if too many
arguments are provided and may cause stack underflows if too few are.

Instead just report to SDL that vsscanf is not supported, which is largely
true, and let it use its own implementation.