### PR TITLE
tools: Only check files that actually exist.

### DIFF
--- a/tools/git-updated-files
+++ b/tools/git-updated-files
@@ -120,7 +120,7 @@ def get_updated_files(path):
 		filename = os.path.join(toplevel, line)
 		if os.path.isdir(filename):
 			diff_files.update(get_updated_files(filename))
-		else:
+		elif os.path.exists(filename):
 			diff_files.add(filename)
 
 	result.update(diff_files)


### PR DESCRIPTION
`git-diff(1)` also lists files that were deleted. Attempting to check
these files results in a 'no such file' error.