### PR TITLE
Github action: Use latest wine on mac(Issue #84)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -133,7 +133,7 @@ jobs:
       run: |
         wget -nc 'http://test.winehq.org/builds/winetest64-latest.exe' 1>&2
         wine64 winetest64-latest.exe -x winetest64 >/dev/null
-        for testname in `wine winetest64/mscoree_test.exe --list 2>/dev/null|sed 's/\r//'|tail -n +2`; do
+        for testname in `wine64 winetest64/mscoree_test.exe --list 2>/dev/null|sed 's/\r//'|tail -n +2`; do
           echo BEGIN $testname TEST 1>&2
           wine64 winetest64/mscoree_test.exe $testname 1>&2 || printf '::warning mscoree:%s test failed\n' $testname
           echo END $testname TEST 1>&2

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -121,9 +121,8 @@ jobs:
     steps:
     - name: Install Wine
       run: |
-        brew install --cask xquartz
-        brew tap homebrew/cask-versions
-        brew install --cask --no-quarantine wine-devel
+        brew tap gcenx/wine
+        brew install --cask --no-quarantine gcenx-wine-devel
     - name: Download Wine Mono msi
       uses: actions/download-artifact@v2
       with:


### PR DESCRIPTION
As Gcenx pointed out, the wine-devel package is out-of-date.