### PR TITLE
macOS workflow: drop custom brew tap

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -167,9 +167,8 @@ jobs:
     steps:
     - name: Install Wine
       run: |
-        brew tap gcenx/wine
         brew install coreutils # for gtimeout
-        brew install --cask --no-quarantine gcenx-wine-devel
+        brew install --cask --no-quarantine homebrew/cask-versions/wine-devel
     - name: Download Wine Mono msi
       uses: actions/download-artifact@v2
       with:


### PR DESCRIPTION
No longer required as brew now directly provides the Winehq WIP macOS packages