### PR TITLE
Fix Linux CI failures

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -112,7 +112,7 @@ jobs:
         sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' 1>&2
         sudo apt update 1>&2
         sudo apt install -y --allow-downgrades libpcre2-8-0:i386 libpcre2-8-0=10.34-7 || true
-        sudo apt install --install-recommends -y --allow-downgrades winehq-devel wine-devel wine-devel-i386 libgphoto2-6:i386 libsane:i386 1>&2
+        sudo apt install --install-recommends -y --allow-downgrades winehq-devel wine-devel wine-devel-i386 libgphoto2-6:i386 libsane:i386 libgd3:i386 1>&2
     - name: Download Wine Mono msi
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -113,6 +113,7 @@ jobs:
         sudo apt update 1>&2
         sudo apt remove -y libnginx-mod-http-image-filter || true
         sudo apt install -y --allow-downgrades libpcre2-8-0:i386 libpcre2-8-0=10.34-7 || true
+        sudo apt install -y --allow-downgrades libgd3:i386=2.2.5-5.2ubuntu2.1 libgd3:i386=2.2.5-5.2ubuntu2.1 || true
         sudo apt install --install-recommends -y --allow-downgrades winehq-devel wine-devel wine-devel-i386 libgphoto2-6:i386 libsane:i386 libgd3:i386 wine-devel-amd64 libgphoto2-6 libsane 1>&2
     - name: Download Wine Mono msi
       uses: actions/download-artifact@v2

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -112,7 +112,7 @@ jobs:
         sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' 1>&2
         sudo apt update 1>&2
         sudo apt install -y --allow-downgrades libpcre2-8-0:i386 libpcre2-8-0=10.34-7 || true
-        sudo apt install --install-recommends -y winehq-devel wine-devel wine-devel-i386 1>&2
+        sudo apt install --install-recommends -y --allow-downgrades winehq-devel wine-devel wine-devel-i386 libgphoto2-6:i386 libsane:i386 1>&2
     - name: Download Wine Mono msi
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -113,7 +113,7 @@ jobs:
         sudo apt update 1>&2
         sudo apt remove -y libnginx-mod-http-image-filter || true
         sudo apt install -y --allow-downgrades libpcre2-8-0:i386 libpcre2-8-0=10.34-7 || true
-        sudo apt install --install-recommends -y --allow-downgrades winehq-devel wine-devel wine-devel-i386 libgphoto2-6:i386 libsane:i386 libgd3:i386 1>&2
+        sudo apt install --install-recommends -y --allow-downgrades winehq-devel wine-devel wine-devel-i386 libgphoto2-6:i386 libsane:i386 libgd3:i386 wine-devel-amd64 1>&2
     - name: Download Wine Mono msi
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -113,7 +113,7 @@ jobs:
         sudo apt update 1>&2
         sudo apt remove -y libnginx-mod-http-image-filter || true
         sudo apt install -y --allow-downgrades libpcre2-8-0:i386 libpcre2-8-0=10.34-7 || true
-        sudo apt install --install-recommends -y --allow-downgrades winehq-devel wine-devel wine-devel-i386 libgphoto2-6:i386 libsane:i386 libgd3:i386 wine-devel-amd64 1>&2
+        sudo apt install --install-recommends -y --allow-downgrades winehq-devel wine-devel wine-devel-i386 libgphoto2-6:i386 libsane:i386 libgd3:i386 wine-devel-amd64 libgphoto2-6 libsane 1>&2
     - name: Download Wine Mono msi
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -111,6 +111,7 @@ jobs:
         sudo apt-key add winehq.key 1>&2
         sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' 1>&2
         sudo apt update 1>&2
+        sudo apt remove -y libnginx-mod-http-image-filter || true
         sudo apt install -y --allow-downgrades libpcre2-8-0:i386 libpcre2-8-0=10.34-7 || true
         sudo apt install --install-recommends -y --allow-downgrades winehq-devel wine-devel wine-devel-i386 libgphoto2-6:i386 libsane:i386 libgd3:i386 1>&2
     - name: Download Wine Mono msi

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -112,7 +112,7 @@ jobs:
         sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' 1>&2
         sudo apt update 1>&2
         sudo apt install -y --allow-downgrades libpcre2-8-0:i386 libpcre2-8-0=10.34-7 || true
-        sudo apt install --install-recommends -y winehq-devel 1>&2
+        sudo apt install --install-recommends -y winehq-devel wine-devel 1>&2
     - name: Download Wine Mono msi
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -112,7 +112,7 @@ jobs:
         sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' 1>&2
         sudo apt update 1>&2
         sudo apt install -y --allow-downgrades libpcre2-8-0:i386 libpcre2-8-0=10.34-7 || true
-        sudo apt install --install-recommends -y winehq-devel wine-devel 1>&2
+        sudo apt install --install-recommends -y winehq-devel wine-devel wine-devel-i386 1>&2
     - name: Download Wine Mono msi
       uses: actions/download-artifact@v2
       with:


### PR DESCRIPTION
This duplicates information from ubuntu and winehq packaging and is thus fragile, but given how long it takes to get answers out of apt when we're NOT doing this, I think it's a good tradeoff.