### PR TITLE
Set exe configs for clr tests.

### DIFF
--- a/mono.make
+++ b/mono.make
@@ -203,6 +203,7 @@ $(BUILDDIR)/mono-unix/builtin-types-32.exe: $(SRCDIR)/mono/mono/mini/builtin-typ
 tests-clr: $(BUILDDIR)/mono-unix/.built-clr-tests $(BUILDDIR)/nunitlite.dll $(BUILDDIR)/fixupclr.exe
 	mkdir -p $(TESTS_OUTDIR)/tests-clr
 	cp $(SRCDIR)/mono/mcs/class/lib/net_4_x/tests/*_test.dll $(SRCDIR)/mono/mcs/class/lib/net_4_x/nunit* $(TESTS_OUTDIR)/tests-clr
+	cp $(SRCDIR)/mono/mcs/class/lib/net_4_x/tests/*_test.dll.nunitlite.config $(TESTS_OUTDIR)/tests-clr
 	cp $(BUILDDIR)/nunitlite.* $(TESTS_OUTDIR)/tests-clr
 	mkdir -p $(TESTS_OUTDIR)/tests-clr/Test/System.Drawing
 	cp -r $(SRCDIR)/mono/mcs/class/System.Drawing/Test/System.Drawing/bitmaps $(TESTS_OUTDIR)/tests-clr/Test/System.Drawing

--- a/tools/run-tests/run-tests.cs
+++ b/tools/run-tests/run-tests.cs
@@ -473,6 +473,11 @@ class RunTests
 		if (fixtures == null)
 			return;
 
+		bool copied_config = false;
+
+		string nunitlite_config = filename+".nunitlite.config";
+		string exe_config = null;
+
 		foreach (var t in fixtures)
 		{
 			string testfixture = t.Item1;
@@ -480,8 +485,18 @@ class RunTests
 
 			if (should_run_fixture(testfixture, arch, run_all))
 			{
+				if (!copied_config && File.Exists(nunitlite_config)) {
+					exe_config = get_nunit_lite_console(arch)+".config";
+					File.Copy(nunitlite_config, exe_config, true);
+					copied_config = true;
+				}
+
 				run_clr_test_fixture(filename, testfixture, arch, testlist, run_all);
 			}
+		}
+
+		if (copied_config) {
+			File.Delete(exe_config);
 		}
 	}
 


### PR DESCRIPTION
Some System.Configuration tests seem to rely on this.