### PR TITLE
GitHub CI: Skip some tests that abort on macOS.

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -220,4 +220,4 @@ jobs:
       run: |
         unzip wine-mono-*-tests.zip 1>&2
         wine reg add 'HKCU\Software\Wine\WineDbg' /v ShowCrashDialog /t REG_DWORD /d 0 /f
-        wine tests/run-tests.exe -fail-list:tests/github-wine-failing.txt -fail-list:tests/github-macos-failing.txt
+        wine tests/run-tests.exe -fail-list:tests/github-wine-failing.txt -fail-list:tests/github-macos-failing.txt -skip-list:tests/github-macos-skip.txt

--- a/tools/run-tests/github-macos-skip.txt
+++ b/tools/run-tests/github-macos-skip.txt
@@ -1,0 +1,2 @@
+MonoTests.System.Windows.Forms.FormThreadTest:TestThreadFormsInit
+MonoTests.System.Windows.Forms.ControlInvokeTest:InvokeTest


### PR DESCRIPTION
This seems to only happen on GitHub CI for some reason, not on a local build, so I don't think it indicates a regression.