### PR TITLE
GitHub CI: Remove --no-quarantine flag.

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -179,7 +179,7 @@ jobs:
         brew update-reset
         brew update
         brew install coreutils # for gtimeout
-        brew install --cask --no-quarantine wine@devel
+        brew install --cask wine@devel
     - name: Download Wine Mono msi
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
This is no longer supported by homebrew and breaks the CI.